### PR TITLE
fix mainClass typo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
-        
+
         			<!-- giant jar -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -50,7 +50,7 @@
 					<archive>
 						<manifest>
 							<addClasspath>true</addClasspath>
-							<mainClass>org.xmlcml.svg2xml.pdf.PDFAnalayzer</mainClass>
+							<mainClass>org.xmlcml.svg2xml.pdf.PDFAnalyzer</mainClass>
 						</manifest>
 					</archive>
 				</configuration>
@@ -73,7 +73,7 @@
 				<configuration>
 					<programs>
 						<program>
-							<mainClass>org.xmlcml.svg2xml.pdf.PDFAnalayzer</mainClass>
+							<mainClass>org.xmlcml.svg2xml.pdf.PDFAnalyzer</mainClass>
 							<id>svg2xml</id>
 						</program>
 					</programs>


### PR DESCRIPTION
minor typo in the main class (prevents java -jar from finding the right class)